### PR TITLE
Fix navigation bar home link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,7 +52,7 @@
                         <section class="top-bar-section">
                             <ul class="title-area">
                               <li class="name">
-                                <a href="{{site.base}}">Home</a>
+                                <a href="{{site.base}}/">Home</a>
                               </li>
                               <li class="toggle-topbar menu-icon"><a href="#">Menu</a></li>
                             </ul>                     


### PR DESCRIPTION
This fix let's the home link always head for the root of the site.  This solves issue https://github.com/FarsetLabs/farsetlabs.github.io/issues/14
