### PR TITLE
GPlus Sucks

### DIFF
--- a/_includes/google_analytics.html
+++ b/_includes/google_analytics.html
@@ -8,5 +8,7 @@
   ga('send', 'pageview');
 
 </script>
-<a href="https://plus.google.com/+FarsetlabsOrgUk" rel="publisher"></a>
+<div style="display:none">
+  <a href="https://plus.google.com/+FarsetlabsOrgUk" rel="publisher"></a>
+</div>
 


### PR DESCRIPTION
Sorry, it looks like google plus verification is literally looking for the string "<a href="https://plus.google.com/+FarsetlabsOrgUk" rel="publisher">Google+</a>" rather than walking the DOM for a publisher link.