### PR TITLE
Update to NEMS Roles

### DIFF
--- a/about/ops_manual.md
+++ b/about/ops_manual.md
@@ -88,7 +88,6 @@ Complaints about the actions of a NEM can and should be raised as per the genera
   * Driving project documentation and PR.
 * Project-Room:
   * Management and monitoring of ‘dirty room’ equipment and resources including but not limited to 3D printer.
-  * PoC for project storage, resources, and documentation
   * Attempting to prevent conflict between member project resource requirements.
 * Digital Infrastructure:
   * Comms, CCTV, Network, maintenance of online presences.

--- a/about/ops_manual.md
+++ b/about/ops_manual.md
@@ -79,9 +79,13 @@ Complaints about the actions of a NEM can and should be raised as per the genera
   * Ensuring appropriate hosting of external visitors.
   * While the responsibility for high level inter-organisational relations lies with the Directors, responsibility for some liaison with external organisations may be adopted at the discretion of the NEM.
 * Community: 
-  * PoC for internal community engagement and conflict resolution.
+  * PoC for internal community engagement
   * Responsible for internal social events and member relations
   * PoC for member induction and 'soft landing' discussions
+* Projects:
+  * PoC for project storage, resources, and documentation
+  * Attempting to prevent conflict between member projects
+  * Driving project documentation and PR.
 * Project-Room:
   * Management and monitoring of ‘dirty room’ equipment and resources including but not limited to 3D printer.
   * PoC for project storage, resources, and documentation

--- a/about/ops_manual.md
+++ b/about/ops_manual.md
@@ -72,24 +72,25 @@ Removal of NEMs from their positions is a Directorship-level decision. A vote of
 Complaints about the actions of a NEM can and should be raised as per the general procedures as set out in the [Code of Conduct](code_of_conduct.html)
 
 ## Proposed Fields and Responsibilities
-* Projects:
-  * PoC for project storage, resources, and documentation
-  * Attempting to prevent conflict between member projects.
-  * Driving project documentation and PR.
 * Events:
   * PoC for booking event space, event management, etc.
   * Ensuring event space is useable for relevant events and co-working overflow.
   * Ensuring appropriate and timely pre- and post- event marketing.
   * Ensuring appropriate hosting of external visitors.
   * While the responsibility for high level inter-organisational relations lies with the Directors, responsibility for some liaison with external organisations may be adopted at the discretion of the NEM.
-* Project-Room: (Vacant!) _(It has been suggested that this be merged with "Projects")_
-  * Management and monitoring (not technical maintenance) of ‘dirty room’ equipment and resources including but not limited to 3D printer.
-  * Partially responsible for ensuring storage is kept reasonably organised.
+* Community: 
+  * PoC for internal community engagement and conflict resolution.
+  * Responsible for internal social events and member relations
+  * PoC for member induction and 'soft landing' discussions
+* Project-Room:
+  * Management and monitoring of ‘dirty room’ equipment and resources including but not limited to 3D printer.
+  * PoC for project storage, resources, and documentation
+  * Attempting to prevent conflict between member project resource requirements.
 * Digital Infrastructure:
   * Comms, CCTV, Network, maintenance of online presences.
   * Maintenance of Documentation on the networks and systems of the space including authentication procedures for all core systems within the space.
-* Facilities (Vacant!):
-  * AV, Electrics, Lighting, Heating, General physical ‘stewardship’ of the coworking and communal areas.
+* Outreach:
+  * PoC for internal and external outreach programme development and partnerships, including overall monitoring of CoderDojo and Raspberry Jam programmes
 
 # Member Role
 

--- a/about/ops_manual.md
+++ b/about/ops_manual.md
@@ -86,7 +86,7 @@ Complaints about the actions of a NEM can and should be raised as per the genera
   * PoC for project storage, resources, and documentation
   * Attempting to prevent conflict between member projects
   * Driving project documentation and PR.
-  * Along with the Projects Room NEM, rives the function and layout of the Project Room to suit the needs of the Farset Community.
+  * Along with the Projects Room NEM, drives the function and layout of the Project Room to suit the needs of the Farset Community.
 * Project-Room:
   * Management and monitoring of Project equipment and resources including but not limited to 3D printer.
   * Attempting to prevent conflict between member project resource requirements.  

--- a/about/ops_manual.md
+++ b/about/ops_manual.md
@@ -86,9 +86,14 @@ Complaints about the actions of a NEM can and should be raised as per the genera
   * PoC for project storage, resources, and documentation
   * Attempting to prevent conflict between member projects
   * Driving project documentation and PR.
+  * Along with the Projects Room NEM, rives the function and layout of the Project Room to suit the needs of the Farset Community.
 * Project-Room:
-  * Management and monitoring of ‘dirty room’ equipment and resources including but not limited to 3D printer.
-  * Attempting to prevent conflict between member project resource requirements.
+  * Management and monitoring of Project equipment and resources including but not limited to 3D printer.
+  * Attempting to prevent conflict between member project resource requirements.  
+  * Coordinates Project Room changes
+  * Along with the Projects NEM, rives the function and layout of the Project Room to suit the needs of the Farset Community.
+  
+
 * Digital Infrastructure:
   * Comms, CCTV, Network, maintenance of online presences.
   * Maintenance of Documentation on the networks and systems of the space including authentication procedures for all core systems within the space.


### PR DESCRIPTION
Updating Ops Manual to realistically reflect current and upcoming NEMS roles: 

Of particular note is the dissolution of Projects NEM, being folded into the Project Room NEM, as well as the dissolution of Facilities position and the creation of an Outreach Nem