### PR TITLE
AD-73 Attempt

### DIFF
--- a/about/child_protection.md
+++ b/about/child_protection.md
@@ -13,7 +13,7 @@ Directors, Managers, Members and Volunteers (agents) within this organisation ac
  
 Farset Labs will review its policy, procedures and practice in this regard at regular intervals, at least every 3 years. 
  
-Farset Labs recognises the Northern Ireland Children’s Order (NICO) (1995), the Safeguarding Vulnerable Groups (SVG) Act 2006, and the Safeguarding Vulnerable Groups (Northern Ireland) Order (SVG(NI)) 2007  and incorporates their principles into its Child Protection Policy and Procedures.
+Farset Labs recognises the [Children Order (Northern Ireland) (1995)](http://www.legislation.gov.uk/nisi/1995/755/contents/made), the [Safeguarding Vulnerable Groups (SVG) Act 2006]( http://www.legislation.gov.uk/ukpga/2006/47/contents) and the [Safeguarding Vulnerable Groups (Northern Ireland) Order (SVG(NI)) 2007](http://www.legislation.gov.uk/nisi/2007/1351/contents) and incorporates their principles into its Child Protection Policy and Procedures.
 
 Under the SVG (NI) Order 2007 FSL is aware that it is a criminal offence to employ someone who is disqualified from working with children and young people in a regulated position.  It is a criminal offence not to dismiss a person who is disqualified from holding a regulated position.  
 
@@ -34,7 +34,7 @@ In order to safeguard children during mixed-group FSL events:-
 
 * No Under-18’s are permitted in the building after 8pm unless accompanied by a parent or guardian
 
-* Unless you are AccessNI cleared, you may not engage in any Regulated Activity in relation to children, defined in the Safeguarding Vulnerable Groups (SVG) Act 2006 and the Safeguarding Vulnerable Groups (Northern Ireland) Order 2007, both as amended (in particular by respectively, section 64 and Schedule 7, Protection of Freedoms Act 2012). This is taken to be as per the latest version of [this DHSSPSNI note on the matter](http://www.dhsspsni.gov.uk/regulated-activity-children.pdf).
+* Unless you are AccessNI cleared, you may not engage in any Regulated Activity in relation to children, defined in the [Safeguarding Vulnerable Groups (SVG) Act 2006](http://www.legislation.gov.uk/ukpga/2006/47/contents) and the [Safeguarding Vulnerable Groups (Northern Ireland) Order 2007](http://www.legislation.gov.uk/nisi/2007/1351/contents), both as amended (in particular by respectively, Sections 64 and 78 and Schedule 7, [Protection of Freedoms Act 2012)](http://www.legislation.gov.uk/ukpga/2012/9/contents/enacted). This is taken to be as per the latest version of [this DHSSPSNI note on the matter](http://www.dhsspsni.gov.uk/regulated-activity-children.pdf).
 
 #Handling Disclosures
 
@@ -42,14 +42,14 @@ In order to safeguard children during mixed-group FSL events:-
 
 When a child discloses abuse:
 
-## 1. Stay calm
+## Stay calm
 An abused or neglected child or youth needs to know that you are available to help them.
 
 Reactions of shock, outrage, or fear make them feel more anxious or ashamed.
 
 A calm response reassures that what has happened is not so bad and can be worked through.
 
-## 2. Go slowly
+## Go slowly
 It is normal to feel inadequate or unsure about what to do or say when a child or youth tells you about their abuse.
 
 Proceed slowly.
@@ -58,11 +58,11 @@ Gentle and open-ended questions such as: "Can you tell me more about what happen
 
 Avoid questions that begin with "why".
 
-## 3. Be reassuring
+## Be reassuring
 Reassure the child or youth that they have not done anything wrong.
 Avoid questions that are usually associated with getting into trouble. Avoid using "why" questions.
 
-## 4. Be supportive
+## Be supportive
 Let the youth or child know:
 * they are not in trouble.
 * they are safe with you.
@@ -72,31 +72,29 @@ Let the youth or child know:
 * you will do everything you can to make sure they are not hurt again.
 * you know others who can be trusted to help solve this problem.
 
-## 5. Get only the essential facts
+## Get only the essential facts
 Be brief.
 
 Limit your discussion to finding out generally what took place.
 
 When you have sufficient information and reason to believe that abuse and/or neglect has occurred, gently stop gathering facts and be supportive.
 
-## 6. Tell what will happen next
+## Tell what will happen next
 Don't make promises to the child about what may or may not happen next.
 
 Provide only reassurance that is realistic and achievable.
 
 Discuss with the child what you think will happen next and who will be involved.
 
-## 7. Report to the child protection worker
+## Report to the child protection worker
 
 Report disclosures of abuse or neglect immediately to a child protection worker for follow-up and investigation.
 
 Express your willingness to help the youth or child through the steps which will follow, if appropriate.
 
-## 8. Make notes
+## Make notes
 
 Make notes of all comments. Use the child's or youth's exact words where possible.
 
 Save all drawings and artwork. This information may need to be shared with social workers and/or the police if appropriate.
-
-
 

--- a/about/code_of_conduct.md
+++ b/about/code_of_conduct.md
@@ -5,50 +5,11 @@ category : pages
 toc : True
 tags : []
 ---
-
-# Summary of Code of Conduct 
-
-While in Farset Labs, you, the members and visitors, are expected to comply to the following Code.
-
-### Access
-
- * Do not lend access cards or keys to anyone;
- * Do not try to access areas you are not allowed to.
-
-### Projects &amp; Equipment
-
- * Do not take others’ equipment or materials without permission;
- * Do not use equipment:
-    * Without training;
-    * If it is unsafe to do so;
-    * That others are currently using;
-    * That is marked as out of order or not to be used.
- * Store your projects and materials safely and with care;
- * Do not bring or use banned or unsafe materials or equipment.
-
-### Housekeeping
-
- * Tidy after yourself;
- * Power down and store equipment properly after use;
- * Keep the space clean, tidy, and pleasant;
- * Live and let live.
- * Park safely &amp; respect the tenants at Weavers’ Court
-
-### Health &amp; Safety
-
- * Do not try to disable safety guards or preventative measures;
- * Be safe and reasonable in everything you do;
- * Report and repair any accidents or damage.
-
-# Code of Conduct
-
-Below is the full text of the Farset Labs Code of Conduct for Members, which all members agree to upon joining Farset Labs. It is available to all members in other formats (See Section 3.2.2) on request.
-
 ## Code of Conduct for Members
 
 This document contains the expected behaviours and obligations that members of Farset Labs are associated with, in addition to a list of banned behaviour and materials. This document references itself as “the Code”, the “Code of Conduct”, and “the Code of Conduct for Members”. The primary location of Farset Labs is referred to as “the space”, “Farset Labs”, and “Farset Labs property”.
 
-The summary document, Section 4, is to be provided and made known to members without request.
+A summary of this code is integrated as part of the general [Rules](rules_and_policies.html) page
 
 ### 1.1 Who the Code applies to
 

--- a/about/facility.md
+++ b/about/facility.md
@@ -2,6 +2,7 @@
 layout: default
 title: Facilities
 parent: "About"
+weight: 3
 toc: False
 ---
 # Facilities & Resources

--- a/about/hardware_donation_license.md
+++ b/about/hardware_donation_license.md
@@ -50,7 +50,7 @@ For example, the image above is a Creative Commons license badge. With just the 
 
 ## Assumed Limitations of Application 
 
-The Restrictions on Use listed in Section 1.7 serve to protect the donator’s wishes for their equipment. This license does not cover restrictions on community projects or items bought collectively by the community, unless the community explicitly agrees to adopt XHDL v1.0 as a method of licensing these items.
+The Restrictions on Use listed in Section 7 serve to protect the donator’s wishes for their equipment. This license does not cover restrictions on community projects or items bought collectively by the community, unless the community explicitly agrees to adopt XHDL v1.0 as a method of licensing these items.
 
 ## Restrictions on Use
 

--- a/about/index.html
+++ b/about/index.html
@@ -12,11 +12,10 @@ haschildren: True
 		{% endcapture %}
 		{{ about_farset | unindent | markdownify }}
 	<hr/>
-<h2>Current Officers</h2>
+<h2>Current Management Board</h2>
 
 <h3 id="directors">Directors</h3>
 <p>Farsets Directors are legally, fiscally, and socially responsible for the strategic health and operation of the Labs</p>
-<p>They are collectively, ultimately responsible for the growth and health of the organisation and it’s community, but are primarily concerned with the financial, legal and strategic running of the organisation.<p>
 {% assign sorted_officers = site.officers | sort:"year" %}
   {% for officer in sorted_officers reversed %}
     {% if officer.title contains "Director" %}
@@ -48,7 +47,6 @@ haschildren: True
 <hr/>
 <h3 id="nems">Non Executive Managers</h3>
 <p>Non-Executive Managers (NEMs) are the primary Points of Contact (PoC) for certain areas, equipment, and activities within the day-to-day operation of the space.</p>
-<p>NEMs represent a limited, non-executive, role in Farset Labs, with no special legal responsibilities or liabilities with respect to the Company.</p>
 {% assign sorted_officers = site.officers | sort:"year" %}
   {% for officer in sorted_officers %}
     {% unless officer.title contains "Director" %}
@@ -71,9 +69,9 @@ haschildren: True
             {% if officer.blurb %}
               {{ officer.blurb | unindent | markdownify }}
             {% endif %}
-            <ul class="button-group round right">
-              {% if officer.email %}<li><a class="button" href="mailto:{{officer.email}}">{{officer.email}} <i class="general foundicon-mail"></i></a></li>{% endif %}
-              {% if officer.discourse %}<li><a class="button" href="{{site.social.forum}}users/{{officer.discourse}}">Get in touch <i class="social foundicon-torso" style="height:51px"></i></a></li>{% endif %}
+            <ul class="small button-group round right">
+              {% if officer.email %}<li><a class="small button" href="mailto:{{officer.email}}">{{officer.email}} <i class="general foundicon-mail"></i></a></li>{% endif %}
+              {% if officer.discourse %}<li><a class="small button" href="{{site.social.forum}}users/{{officer.discourse}}">Get in touch <i class="social foundicon-torso" style="height:51px"></i></a></li>{% endif %}
             </ul>
             
         </div>
@@ -81,8 +79,13 @@ haschildren: True
     {% endunless %}
 {% endfor %}
 
-For more information about the roles and responsibilities of the officers of Farset Labs, see the <a href="/about/ops_manual.html">Ops Manual</a>
+<div class="block row">
+    <div class="small-12 columns">
+    For more information about the roles and responsibilities of the officers of Farset Labs, see the <a href="/about/ops_manual.html">Ops Manual</a>
+    </div>
+</div>
 
+<hr/>
 
 <h2>Farset Labs Former Officers</h2>
 <div class="block row">

--- a/about/rules_and_policies.md
+++ b/about/rules_and_policies.md
@@ -5,10 +5,11 @@ category : pages
 parent : "About"
 haschildren: True
 toc : False
+weight: 4
 tags : []
 ---
 
-# Dem Rules 
+# The Short Rules 
 
 Any community needs a few rules to stay safe and fun, and we don't like making more than we have to. 
 
@@ -19,7 +20,72 @@ These can be summarised in two statements:
 
 If this is somehow not clear or you believe you have found a loophole, please read on.
 
-# Specific Policies
+## Slightly Longer Rules
+
+While in Farset Labs, you, the members and visitors, are expected to comply to the following Code.
+
+### Culture and Ethos
+
+ * Be Excellent to each other;
+ * Don't disturb those who do not want to be disturbed;
+ * If you see something and it doesn't look right or safe, it probably isn't so ask/tell someone about it.
+ * [Intolerance will not be tolerated](equality.html);
+
+### Handling of Complaints and Breaches
+ * Technical issues related to the space may be raised through our [Issue Tracker](http://jira.farsetlabs.org.uk)
+ * All members should endeavour to resolve minor personal issues directly with the persons involved;
+ * If this is not possible, the following general approach is to be applied (with exceptions for complaints towards office holders outlined in the [Ops Manual](ops_manual.html);
+    * Raise a complaint to either the [Directors](mailto:admin@farsetlabs.org.uk) or [NEMs](mailto:nems@services.farsetlabs.org.uk) detailing the issue and the persons involved. Reports may be anonymously filed but this will slow the response, as the management board[^1] will first have to corroborate the claims raised.
+    * The issue will be raised at the next Management meeting and, at that boards discretion, directly with the persons involved.
+    * After at most one bi-weekly management meeting, a response will be issued by a member of the management board[^1] that may result in a warning or subsequent expulsion of those involved.
+
+[^1]: The Management Board consists of both the Directors of Farset Labs and the Non-Executive Mangers (NEMs)
+
+### Access
+
+ * Do not lend access cards or keys to anyone;
+ * Do not try to access areas you are not allowed to.
+
+### Projects &amp; Equipment
+
+ * Do not take others’ equipment or materials without permission;
+ * Do not use equipment:
+    * Without training;
+    * If it is unsafe to do so;
+    * That others are currently using;
+    * That is marked as out of order or not to be used.
+ * Store your projects and materials safely and with care;
+ * Do not bring or use banned or unsafe materials or equipment;
+ * All personal equipment being left or stored in the space must be labeled under the [HDL](hardware_donation_license.html) with, at least, the owners contact details and a "GB DND" clause (Give Back, Do Not Disassemble).
+ * Any equipment brought to the space with the intention of being [donated](/about/donations.html) for communal use must be labelled as such as per the [HDL](hardware_donation_license.html), and confirmed via [donate@farsetlabs.org.uk](mailto:donate@farsetlabs.org.uk) in advance.
+
+### Housekeeping
+
+ * Leave the space better than you found it;
+ * Power down and store equipment properly after use;
+ * Keep the space clean, tidy, and pleasant;
+ * Live and let live;
+ * Do not be either on fire or asleep in the space;
+ * Park safely &amp; respect the tenants at Weavers’ Court
+
+### Health &amp; Safety
+
+ * Do not try to disable safety guards or preventative measures;
+ * Be safe and reasonable in everything you do;
+ * Report and repair any accidents or damage.
+
+### Child Protection
+ * No Under 18's may join Farset Labs as members;
+ * No unaccompanied[^2] under 18's are permitted in the building after 8pm;
+ * No unaccompanied[^2] under 14's are permitted in the building;
+ * No unidentified individuals are permitted in mixed-age-group events;
+ * At least two agents of Farset Labs must remain with any mixed-age-group event at all times;
+ * Agents and Officers cannot engage in any Regulated Activity as defined in the [CPP](child_protection.html) unless they are Access NI Cleared as part of a Farset Labs project or programme.
+
+[^2]: Within Farset Labs, "unaccompanied" means a young person without an attending parent, guardian, or agent of Farset Labs operating in loco parentis by prior agreement
+
+
+## The Very Much Longer Rules
 * [Code of Conduct](code_of_conduct.html)
 * [Operations Manual](ops_manual.html)
 * [Child Protection Policy](child_protection.html)


### PR DESCRIPTION
Giving AD-73 a go; also includes weighting tweaks to normalise order of listings under About, clean up some cruff from the about page, and in general clean things up just a little.

Summarises pretty much all the rules under one page, as well as cleaning up some of the links, particularly in the CPP, and matching button types in the about page.

