### PR TITLE
include updated available jekyll plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,9 @@ exclude: [README.md, _scripts, Gemfile, Gemfile.lock, etc, bin, makefile, buildo
 plugins: ./_plugins
 base: ""
 gems:
+  - jekyll-mentions
+  - jemoji
+  - jekyll-redirect-from
   - jekyll-sitemap
 paginate_path: "news/page:num"
 paginate: 5


### PR DESCRIPTION
Updated GH Jekyll plugins;

https://help.github.com/articles/using-jekyll-plugins-with-github-pages/

Includes new github-compatible [emoji](https://github.com/jekyll/jemoji), [GH mentions](https://github.com/jekyll/jekyll-mentions) and markdown-based [redirection](https://github.com/jekyll/jekyll-redirect-from) which should be really useful to maintaining links in the future.