### PR TITLE
Sponsored Membership Policy

### DIFF
--- a/about/rules_and_policies.md
+++ b/about/rules_and_policies.md
@@ -95,3 +95,4 @@ While in Farset Labs, you, the members and visitors, are expected to comply to t
 * [Child Protection Policy](child_protection.html)
 * [Equality Policy](equality.html)
 * [Hardware Donation License](hardware_donation_license.html)
+* [Sponsored Membership Policy](sponsored_membership_policy.html)

--- a/about/sponsored_membership_policy.md
+++ b/about/sponsored_membership_policy.md
@@ -9,19 +9,21 @@ weight: 4
 tags : []
 ---
 
-# Terms
+# Sponsored Membership Policy
+
+## Terms
 
 * FSL - Farset Labs
 * SO - Sponsoring Organisation
 
-# Context
+## Context
 
 An organisation may wish to sponsor FSL memberships. That SO may
 negotiate what membership levels (Student, Standard, Freelance) or
 extras (Desk Rental) with FSL, and the price may be discounted for bulk
 sponsorships at the discretion of FSL management.
 
-# General Points
+## General Points
 
 There is no limit on the holding duration of sponsored memberships,
 however transfers of sponsored membership to third parties must be
@@ -46,15 +48,14 @@ out with no notification, FSL reserves the right to refuse a
 notification of registration that would take the SO over their
 sponsorship quota.
 
-# Registration Process
+## Registration Process
 
 1.  SO selects persons from its cohort / target audience by selection
     or advertising of the sponsored memberships. FSL will happily assist
     in the promotion of this, and the SO may ask to have the sponsorship
     presented on the FSL website / promotional materials. 
 
-2.  SO notifies FSL via
-    [admin@farsetlabs.org.uk](mailto:admin@farsetlabs.org.uk)
+2.  SO notifies FSL via [join@farsetlabs.org.uk](mailto:join@farsetlabs.org.uk)
     using the subject “Sponsored Membership Notification” including: 
     1.  Name of sponsored member 
     2.  Contact Email of sponsored member 
@@ -67,7 +68,7 @@ sponsorship quota.
     member via their contact address, including standard member
     onboarding notification 
 
-# Payment Process
+## Payment Process
 
 There are three options for payment of sponsored memberships. Once the
 payment process has been agreed upon, it cannot be changed without
@@ -86,7 +87,7 @@ renegotiation of the sponsorship agreement.
         memberships registered / active that month.
     -   New registrations will be rounded up/down to the nearest month. 
 
-# Contact
+## Contact
 
 For any enquiries about sponsoring memberships to Farset Labs, please 
-contact [admin@farsetlabs.org.uk](mailto:admin@farsetlabs.org.uk)
+contact [join@farsetlabs.org.uk](mailto:join@farsetlabs.org.uk)

--- a/about/sponsored_membership_policy.md
+++ b/about/sponsored_membership_policy.md
@@ -1,0 +1,92 @@
+---
+title: Sponsored Memberships
+layout: default
+category : pages
+parent : False
+haschildren: False
+toc : False
+weight: 4
+tags : []
+---
+
+# Terms
+
+* FSL - Farset Labs
+* SO - Sponsoring Organisation
+
+# Context
+
+An organisation may wish to sponsor FSL memberships. That SO may
+negotiate what membership levels (Student, Standard, Freelance) or
+extras (Desk Rental) with FSL, and the price may be discounted for bulk
+sponsorships at the discretion of FSL management.
+
+# General Points
+
+There is no limit on the holding duration of sponsored memberships,
+however transfers of sponsored membership to third parties must be
+confirmed with FSL in advance of transfer.
+
+Sponsored Memberships are taken to be completely equivalent to regular
+memberships, including all relevant resource, space, and voting
+privileges.
+
+In the case of any misconduct or disciplinary issues, FSL reserves the
+right to engage the SO as well as the sponsored member.
+
+Sponsored Memberships will generally be negotiated in terms of Annual
+Memberships per Person, but these memberships are divisible down to
+monthly memberships at the discretion of the SO (pending notification
+processing).
+
+It is the responsibility of FSL to monitor and account for the
+Sponsorship Balance and to notify the SO when they are near the end of
+their agreed sponsorship quota, however, in the event this quota runs
+out with no notification, FSL reserves the right to refuse a
+notification of registration that would take the SO over their
+sponsorship quota.
+
+# Registration Process
+
+1.  SO selects persons from its cohort / target audience by selection
+    or advertising of the sponsored memberships. FSL will happily assist
+    in the promotion of this, and the SO may ask to have the sponsorship
+    presented on the FSL website / promotional materials. 
+
+2.  SO notifies FSL via
+    [admin@farsetlabs.org.uk](mailto:admin@farsetlabs.org.uk)
+    using the subject “Sponsored Membership Notification” including: 
+    1.  Name of sponsored member 
+    2.  Contact Email of sponsored member 
+    3.  Duration of sponsorship in calendar months 
+    4.  (Optional, Default No) Whether or not the SO wishes to be
+        included in ongoing sponsored member correspondence regarding
+        membership 
+
+3.  FSL will confirm receipt with the SO and will notify the sponsored
+    member via their contact address, including standard member
+    onboarding notification 
+
+# Payment Process
+
+There are three options for payment of sponsored memberships. Once the
+payment process has been agreed upon, it cannot be changed without
+renegotiation of the sponsorship agreement.
+
+-   In Advance 
+    -   On agreement of a sponsoring programme, FSL will invoice the SO
+        for the full agreed balance of the sponsorship.  
+
+-   Per-Member in Advance 
+    -   On registration, the FSL will invoice the SO for the proposed
+        duration of a single member's sponsorship period. 
+
+-   Monthly 
+    -   FSL will invoice the SO each month for the number of sponsored
+        memberships registered / active that month.
+    -   New registrations will be rounded up/down to the nearest month. 
+
+# Contact
+
+For any enquiries about sponsoring memberships to Farset Labs, please 
+contact [admin@farsetlabs.org.uk](mailto:admin@farsetlabs.org.uk)

--- a/membership/index.html
+++ b/membership/index.html
@@ -33,7 +33,7 @@ image: /membership/membership_800.jpg
 <p>There are three Individual Membership rates that we think represent three core uses of the space; </p>
 
 <ul>
-  <li><strong>Students</strong> (£15pm), that are occasionally in the space during the day, mostly experiment in the evenings, and are strapped for cash <sup id="fnref:cards"><a href="#fn:cards" class="footnote">2</a></sup></li>
+  <li><strong>Students</strong> (£15pm), that are occasionally in the space during the day, mostly experiment in the evenings, and are strapped for cash <sup id="fnref:cards"><a href="#fn:cards" class="footnote">1</a></sup></li>
   <li><strong>Enthusiasts</strong> (£25pm), that regularly use the space in the evenings and make regular use of the equipment and space</li>
   <li><strong>Freelancers</strong> (£35pm), that are consistently in the space, regularly hot-desking with ongoing long term projects under their belts</li>
 </ul>
@@ -69,13 +69,18 @@ image: /membership/membership_800.jpg
 </table>
 </form>
 
-<p>If you don’t wish to use PayPal contact us on <a href="mailto:membership@farsetlabs.org.uk">membership@farsetlabs.org.uk</a> to discuss alternative payment schemes such as Invoicing, BACS, Standing Orders, or Cash balances.</p>
+<p>If you don’t wish to use PayPal contact us on <a href="mailto:join@farsetlabs.org.uk">join@farsetlabs.org.uk</a> to discuss alternative payment schemes such as Invoicing, BACS, Standing Orders, or Cash balances.</p>
+
+<hr>
+<h1 id='sponsored-memberships'>Sponsored Memberships</h1>
+
+<p>If your company, organisation or institution is interested in sponsoring memberships to Farset Labs for your community, as prizes, opportunities or otherwise, please review our <a href="/about/sponsored_membership_policy.html">Sponsored Membership Policy</a> and contact us on <a href="mailto:join@farsetlabs.org.uk">join@farsetlabs.org.uk</a></p>
 
 <hr>
 
 <h1 id='friend-of-farset'> Friends of Farset</h1>
 <p>If you're not in a position to make regular use of the space but still want to support us, consider signing up as a Friend of Farset! Your donations will go towards the upkeep of the space and it's community and if you want to support anything in particular, you can say so in the form!</p>
-<p>Friends of Farset are welcome to attend most Farset events<sup id="fnref:events"><a href="#fn:events" class="footnote">1</a></sup> and can always avail of the £5 day passes if they find themselves in need of workspace! If you are coming down, please remember to sign the GuestBook at reception when you come in!</p>
+<p>Friends of Farset are welcome to attend most Farset events<sup id="fnref:events"><a href="#fn:events" class="footnote">2</a></sup> and can always avail of the £5 day passes if they find themselves in need of workspace! If you are coming down, please remember to sign the GuestBook at reception when you come in!</p>
 <form class="text-center" action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
   <input type="hidden" name="cmd" value="_s-xclick">
   <input type="hidden" name="hosted_button_id" value="6E5VFUY63DKLS">
@@ -87,11 +92,11 @@ image: /membership/membership_800.jpg
 <hr>
 <div class="footnotes">
   <ol>
-    <li id="fn:events">
-    <p>Some events requiring the purchase of specialised equipment and/or parts may require a supplementary fee to participate <a href="#fnref:events" class="reversefootnote">↩</a></p>
-    </li>
     <li id="fn:cards">
     <p>All student members must hold current, valid, student ID’s for the duration of their membership at that level <a href="#fnref:cards" class="reversefootnote">↩</a></p>
+    </li>
+    <li id="fn:events">
+    <p>Some events requiring the purchase of specialised equipment and/or parts may require a supplementary fee to participate <a href="#fnref:events" class="reversefootnote">↩</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
Also includes crosslinks to membership page, updates membership emails to join@farsetlabs.org.uk to deconflict with proposed members@farsetlabs.org.uk email list. 