### PR TITLE
remove google+ social icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,6 @@ url: "http://www.farsetlabs.org.uk"
 social:
   github: FarsetLabs
   facebook: FarsetLabs
-  gplus: FarsetLabsOrgUk
   twitter: FarsetLabs
   flickr: groups/farset_labs
   blogfeed: "http://blog.farsetlabs.org.uk/feed/"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,7 +72,6 @@
                       <li><a href="//www.github.com/{{site.social.github}}" rel="publisher"><i class="social foundicon-github"></i></a></li>
                       <li><a href="//www.twitter.com/{{site.social.twitter}}" rel="publisher"><i class="social foundicon-twitter"></i></a></li>
                       <li><a href="//www.facebook.com/{{site.social.facebook}}" rel="publisher"><i class="social foundicon-facebook"></i></a></li>
-                      <li><a href="https://plus.google.com/+{{site.social.gplus}}" rel="publisher"><i class="social foundicon-google-plus"></i></a></li>
                       <li><a href="//www.flickr.com/{{site.social.flickr}}"><i class="social foundicon-flickr"></i></a></li>
                       <li><a href={{site.social.blogfeed}}><i class="social foundicon-rss"></i></a></li>
                     </ul>


### PR DESCRIPTION
Google+ is soon to be dead.

https://www.blog.google/technology/safety-security/project-strobe/