### PR TITLE
Added a new page outlining the aims of the charity.

### DIFF
--- a/about/charitable_aims.md
+++ b/about/charitable_aims.md
@@ -12,7 +12,7 @@ The objects of Farset Labs are the education of the public in STEAM (Science, Te
 
 ### Facilitation
 
-The direct benefits which flow from the facilitationof STEAM Education, Entrepreneurship, and Experimentation include improved technical and non technical competencies within and around the STEAM fields, improving employability, personal development and productivity of those beneficiaries
+The direct benefits which flow from the facilitation of STEAM Education, Entrepreneurship, and Experimentation include improved technical and non technical competencies within and around the STEAM fields, improving employability, personal development and productivity of those beneficiaries
 
 There is also an indirect benefit of providing a knowledge sharing community across the wide range of STEAM fields, further facilitating the purposes of the organisation.
 

--- a/about/charitable_aims.md
+++ b/about/charitable_aims.md
@@ -1,0 +1,40 @@
+---
+title: Charitable Aims
+layout: default
+category : pages
+toc : True
+tags : []
+---
+
+# {{ page.title }}
+The objects of Farset Labs are the education of the public in STEAM (Science, Technology, Engineering, Arts and Mathematics) and the provision of community accessible workspaces to facilitate STEAM outreach and education in Northern Ireland, primarily focused in the Belfast area.
+
+
+### Facilitation
+
+The direct benefits which flow from the facilitationof STEAM Education, Entrepreneurship, and Experimentation include improved technical and non technical competencies within and around the STEAM fields, improving employability, personal development and productivity of those beneficiaries
+
+There is also an indirect benefit of providing a knowledge sharing community across the wide range of STEAM fields, further facilitating the purposes of the organisation.
+
+These benefits are demonstrated through feedback from users of the space, members, and event attendees, as well as recognition of the impact of the organisation by significant bodies such as NESTA, STEMNET, the Northern Ireland Science Park, Queen’s University Belfast, The University of Ulster, Tibus Connect, and Intel Ireland.
+
+In providing a collaborative space for people making use of the organisations resources, there are a variety of associated health and safety risks that are minimised by appropriate operational standards and insurances. Such incidents are rare and the benefit outweighs the harm.
+
+The organisation’s beneficiaries are people within and around the Greater Belfast Area who can access the organisation's facilities, who have an interest in STEAM topics but may not have access to the required resources or space to grow their knowledge and experience. These include but are not restricted to Children, Young People, Students, Researchers, Professionals, the Unemployed / Underemployed and Entrepreneurs.
+
+A private benefit to trustees is the normal use of the resources and space provided to all beneficiaries, and this is incidental and necessary to ensure the benefit is provided and maintained for all beneficiaries.
+
+
+### Promotion and Education
+
+The direct benefits of the promotion of STEAM Education, Entrepreneurship, and Experimentation include introducing beneficiaries to STEAM fields with immersive and exciting outreach and education programmes driven by practitioners in their respective fields. These programmes lead to a higher level of interest in STEAM, increasing overall quality of life, and understanding of the modern world, whether beneficiaries continue in a STEAM field or not.
+
+The impact of STEAM promotion and outreach is well established, but its impacts are long term; increased uptake in STEAM subjects at higher education, increase in employment and activity in the Knowledge Sector, leading to higher overall productivity and quality of life, again supported by work done.
+
+This purpose may present potential risks to children, however by adherence to all relevant child protection laws and statutes in Northern Ireland, this risk is minimised and the benefit outweighs the harm.
+
+This promotional purpose is primarily but not exclusively aimed at Children and Young People, as well as indirectly benefiting their families / teachers / schools through increased relationships and sharing of best practices for making STEAM engaging and exciting for the beneficiaries.
+
+Trustees that participate and represent the charity at educational, promotional or outreach events gain experience that can aid their future employment prospects. These benefits are incidental and necessary to ensure the benefits of the organisation are provided to our beneficiaries.
+
+In some cases, these same people will receive reasonable financial compensation of expenses related to such activities where these activities are exclusively in line with the purposes of the organisation. This benefit is incidental and necessary to ensure the benefit is provided to our beneficiaries.


### PR DESCRIPTION
Added a new page under About to detail the aims of Farset as a
registered charity in NI.

Taken directly from the Charity Commission's website:
https://www.charitycommissionni.org.uk/charity-details/?regId=102754&subId=0

Fixes #204 