### PR TITLE
Provide a redirect to the Slack sign-up page.

### DIFF
--- a/slack/index.md
+++ b/slack/index.md
@@ -1,4 +1,3 @@
 ---
-title: Events & Classes
 redirect_to: https://slackin.farsetlabs.org.uk/
 ---

--- a/slack/index.md
+++ b/slack/index.md
@@ -1,0 +1,4 @@
+---
+title: Events & Classes
+redirect_to: https://slackin.farsetlabs.org.uk/
+---


### PR DESCRIPTION
If a user browses to /slack they will now be redirected to
https://slackin.farsetlabs.org.uk/

"How do I access the Slack?

If you just go to the website farsetlabs.org.uk forward slash slack it should direct you to a page to sign-up."

Provides a way to be able to offer a simple direction to someone asking about how to access the Slack.