### PR TITLE
Update GitHub metadata. 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Farset Labs
+title: Farset Labs
 description: "Northern Ireland's Hackerspace"
 tags: "hackerspace, makerspace, belfast, technology, maker movement"
 markdown: kramdown

--- a/slack/index.md
+++ b/slack/index.md
@@ -1,0 +1,4 @@
+---
+title: Events & Classes
+redirect_to: https://slackin.farsetlabs.org.uk/
+---

--- a/slack/index.md
+++ b/slack/index.md
@@ -1,4 +1,0 @@
----
-title: Events & Classes
-redirect_to: https://slackin.farsetlabs.org.uk/
----


### PR DESCRIPTION
Jekyll was complaining about the _config.yml having the sitename
configured as site.name instead of site.title as many plugins and themes
expect it to be.

![Screen Shot 2019-12-04 at 18 52 44](https://user-images.githubusercontent.com/25280584/70172171-0ae0db00-16c8-11ea-8f98-1ca0695c1063.png)

