### PR TITLE
Update GitHub metadata.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Farset Labs
+title: Farset Labs
 description: "Northern Ireland's Hackerspace"
 tags: "hackerspace, makerspace, belfast, technology, maker movement"
 markdown: kramdown


### PR DESCRIPTION
Jekyll was complaining about the _config.yml having the sitename
configured as site.name instead of site.title as many plugins and themes
expect it to be.

![Screen Shot 2019-12-04 at 19 22 02](https://user-images.githubusercontent.com/25280584/70173741-652f6b00-16cb-11ea-8dd3-191228c0d187.png)
