### PR TITLE
[NAVIGATION] Split Out "Join" and "Visit" Options

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -2,7 +2,7 @@
 layout: default
 title: About
 category: nav
-weight: 3
+weight: 4
 haschildren: True
 ---
 

--- a/events/index.md
+++ b/events/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Events & Classes
 category: nav
-weight: 4
+weight: 5
 redirect_from:
   - /calendar
 haschildren: True

--- a/hotdesk/index.html
+++ b/hotdesk/index.html
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Hot-Desk
-parent: "Join"
-weight: 2
+title: Visit
+category: nav
+weight: 1
 image: /hotdesk/Coworking_pano_800.jpg
 ---
 <div class="small-12 columns">

--- a/membership/index.md
+++ b/membership/index.md
@@ -2,8 +2,7 @@
 layout: default
 title: Join
 category: nav
-weight: 1
-haschildren: true
+weight: 2
 image: /membership/membership_800.jpg
 ---
 Membership Benefits

--- a/support/index.md
+++ b/support/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Support
 category: nav
-weight: 2
+weight: 3
 redirect_from: /donate
 haschildren: True
 ---


### PR DESCRIPTION
## Description

Splits out "Visit" into its own navigation item because it's not intuitive to find a one-time day pass under "Join".

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/78502612-e1a98780-7759-11ea-97df-daaca5a65a81.png) | ![image](https://user-images.githubusercontent.com/13058213/78502629-eff7a380-7759-11ea-84fc-1efb3fd9dc3b.png)
