### PR TITLE
[HOMEPAGE] Override Carousel Styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,8 +161,8 @@
         <section id="page-content" class="content">
           {% if page.carousel %}
           <div class="row carousel">
-            <div class="flex-container">
-              <div class="flexslider">
+            <div class="flex-container small-12 columns">
+              <div class="flexslider carousel-slider-overrides">
                 <ul class="slides">
                   {% for slides in page.carousel %}
                   <li>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -87,6 +87,13 @@ a {
   margin-bottom: 1.25rem;
 }
 
+.carousel-slider-overrides {
+  padding: 0;
+  background: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
 .directors {
 
   }


### PR DESCRIPTION
## Description

Override some styles to make the photo slides look clean and flush with the page layout.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/78503721-51bb0c00-7760-11ea-8ec0-d795f893ce51.png) | ![image](https://user-images.githubusercontent.com/13058213/78503752-7ca56000-7760-11ea-9396-0ab7c798d083.png)


