### PR TITLE
[No Issue] Correct Blog Link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ links:
     - name: Slack
       url: "https://farsetlabs.org.uk/slack"
     - name: Blog
-      url: "https://blog.farsetlabs.org.uk/feed/"
+      url: "https://blog.farsetlabs.org.uk/"
     - name: Flickr
       url: "https://www.flickr.com/groups/farset_labs"
 officers:


### PR DESCRIPTION
## Description

There are two "Blog" links in the navigation and one of them was pointing at the RSS feed, which was counterintuitive.

There is a separate RSS feed link.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/13058213/81421661-b4316e80-9149-11ea-946f-d9f5952f2c22.gif) | ![after](https://user-images.githubusercontent.com/13058213/81421670-ba274f80-9149-11ea-9dae-e8f5c5f62a92.gif)

