### PR TITLE
[ISSUE-260] Show Contributors to the Website on the Website

### DIFF
--- a/about/contributors.html
+++ b/about/contributors.html
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Contributors
+parent: About
+---
+{% comment %}Using the jekyll-github-metadata plugin included with github-pages.{% endcomment %}
+{% comment %}These assignments will randomise the order of listing contributors on deployment.{% endcomment %}
+{% assign number_of_contributors = site.github.contributors | size %}
+{% assign contributors = site.github.contributors | sample: number_of_contributors %}
+
+<p id="contributors__overview">Our wesite is open source and we welcome contributions from everyone. It is built by a whole lot of wonderful people.</p>
+<ul id="contributors">
+  {% for contributor in contributors %}
+    <li class="contributor">
+      <a href="{{contributor.html_url}}" class="contributor__link">
+        <img src="{{contributor.avatar_url}}" class="contributor__avatar">
+        <span class="contributor__name">{{ contributor.login }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -106,3 +106,35 @@ a {
    display: none;
   }
 }
+
+#contributors__overview {
+  text-align: center;
+}
+
+#contributors {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 0;
+}
+
+.contributor {
+  list-style: none;
+}
+
+.contributor__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 5px;
+}
+
+.contributor__avatar {
+  width: 100px;
+}
+
+.contributor__name {
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
[ISSUE-260](https://github.com/FarsetLabs/farsetlabs.github.io/issues/260)

## Description

Add a "Contributors" page under the "About" section showing all contributors to our website.

Closes #260.

Desktop |
--- |
![image](https://user-images.githubusercontent.com/13058213/81488162-2fd01000-925d-11ea-820d-2da35283eee3.png)

Mobile | 
--- |
![image](https://user-images.githubusercontent.com/13058213/81488163-32326a00-925d-11ea-90cf-28f4c2b92634.png)

