### PR TITLE
Spelling Mistake

### DIFF
--- a/about/contributors.html
+++ b/about/contributors.html
@@ -8,7 +8,7 @@ parent: About
 {% assign number_of_contributors = site.github.contributors | size %}
 {% assign contributors = site.github.contributors | sample: number_of_contributors %}
 
-<p id="contributors__overview">Our wesite is open source and we welcome contributions from everyone. It is built by a whole lot of wonderful people.</p>
+<p id="contributors__overview">Our website is open source and we welcome contributions from everyone. It is built by a whole lot of wonderful people.</p>
 <ul id="contributors">
   {% for contributor in contributors %}
     <li class="contributor">


### PR DESCRIPTION
[(Example) ISSUE-247](https://github.com/FarsetLabs/farsetlabs.github.io/issues/247)

## Description

'website' spelt incorrectly on Contributors page

Before | After
--- | ---
`s/wesite|website/g`
