### PR TITLE
Tell git to ignore tracking Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 etc
 bin
 *.swp
+Gemfile.lock


### PR DESCRIPTION
Should prevent bundle from complaining about different versioning issues.