### PR TITLE
[No Issue] Relocate "Fundraising Regulator" Badge

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -202,11 +202,7 @@
               {{ footer | unindent | markdownify }}
             </div>
             <div class="small-6 columns text-right">
-		<a href="https://fundraisingregulator.org.uk">
-		  <img src="{{site.base}}/assets/img/fr_badge.png" alt='Registered with the Fundraising Regulator'>
-		</a>
-		</br>
-                <a href="http://jekyllrb.com">Jekyll</a> theme by <a href="http://argskwargs.io">averagehuman</a>.
+              <a href="http://jekyllrb.com">Jekyll</a> theme by <a href="http://argskwargs.io">averagehuman</a>.
             </div>
         </div>
         </section>

--- a/about/index.html
+++ b/about/index.html
@@ -12,6 +12,13 @@ haschildren: True
     {% endcapture %}
     {{ about_farset | unindent | markdownify }}
   <hr/>
+
+<a href="https://fundraisingregulator.org.uk">
+  <img src="{{site.base}}/assets/img/fr_badge.png" alt='Registered with the Fundraising Regulator'>
+</a>
+
+<hr/>
+
 <h2>Current Management Board</h2>
 
 <h3 id="directors">Directors</h3>


### PR DESCRIPTION
## Description

Relocate the "Registered with fundraising regulator" badge. I think it looks significantly neater this way.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/82160406-10ed0180-988d-11ea-8055-41e234c0f155.png) | ![image](https://user-images.githubusercontent.com/13058213/82160409-14808880-988d-11ea-9737-d1da5fe2737c.png)
![image](https://user-images.githubusercontent.com/13058213/82160419-22360e00-988d-11ea-8111-3c903d351dbb.png) | ![image](https://user-images.githubusercontent.com/13058213/82160421-24986800-988d-11ea-84cc-3c78765fbb89.png)