### PR TITLE
[ISSUE-276] Adjust Header and Footer

### DIFF
--- a/_includes/pages/footer.md
+++ b/_includes/pages/footer.md
@@ -1,4 +1,0 @@
-
-Copyright [Farset Labs](https://farsetlabs.org.uk) {{ site.time | date: '%Y' }}.
-
-[Farset Labs](https://www.farsetlabs.org.uk/) is a [Registered Charity (NIC102754)](https://www.charitycommissionni.org.uk/charity-details/?regId=102754&subId=0) and a non-profit [Private Limited Company (NI611278)](https://beta.companieshouse.gov.uk/company/NI611278), based in Belfast, Northern Ireland.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -193,14 +193,14 @@
           <div class="row">
             <div class="small-12 medium-6 columns">
               <ul id="social-media-icons" class="inline-icons inline-list">
-                <li><a href="{{site.social.github}}" rel="publisher"><i class="social foundicon-github"></i></a></li>
-                <li><a href="{{site.social.twitter}}" rel="publisher"><i class="social foundicon-twitter"></i></a></li>
-                <li><a href="{{site.social.facebook}}" rel="publisher"><i class="social foundicon-facebook"></i></a></li>
-                <li><a href="{{site.social.slack}}" rel="publisher"><i class="fab fa-slack-hash" style="padding-top: 10px;"></i></a>
-                <li><a href="{{site.social.flickr}}"><i class="social foundicon-flickr"></i></a></li>
-                <li><a href="{{site.social.instagram}}"><i class="social foundicon-instagram"></i></a></li>
-                <li><a href="{{site.social.blogfeed}}"><i class="social foundicon-rss"></i></a></li>
-                <li><a href="{{site.social.twitch}}" rel="publisher"><i class="fab fa-twitch" style="padding-top: 10px;"></i></a>
+                <li><a href="{{site.social.github}}" rel="publisher"><i class="fab fa-github"></i></a></li>
+                <li><a href="{{site.social.twitter}}" rel="publisher"><i class="fab fa-twitter"></i></a></li>
+                <li><a href="{{site.social.facebook}}" rel="publisher"><i class="fab fa-facebook-square"></i></a></li>
+                <li><a href="{{site.social.slack}}" rel="publisher"><i class="fab fa-slack"></i></a>
+                <li><a href="{{site.social.flickr}}"><i class="fab fa-flickr"></i></a></li>
+                <li><a href="{{site.social.instagram}}"><i class="fab fa-instagram"></i></a></li>
+                <li><a href="{{site.social.blogfeed}}"><i class="fas fa-rss"></i></a></li>
+                <li><a href="{{site.social.twitch}}" rel="publisher"><i class="fab fa-twitch"></i></a>
               </ul>
             </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -63,28 +63,20 @@
 </head>
 <body>
     <div id="page-wrap">
-        <div id="banner-wrap">
-            <div class="row">
-              <div class="small-7 columns">
-                <h1 class="banner">
-                  <a href="/">
-                    <img src="{{site.base}}/assets/img/logo-pride_60.png"/>
-                    <span class="fsl-purple">Farset</span><span class="fsl-green">Labs</span><small class="subheader"> BELFAST</small></a></h1>
-                </div>
-                <div class="small-5 columns">
-                    <ul class="inline-icons inline-list right">
-                      <li><a href="{{site.social.github}}" rel="publisher"><i class="social foundicon-github"></i></a></li>
-                      <li><a href="{{site.social.twitter}}" rel="publisher"><i class="social foundicon-twitter"></i></a></li>
-                      <li><a href="{{site.social.facebook}}" rel="publisher"><i class="social foundicon-facebook"></i></a></li>
-                      <li><a href="{{site.social.slack}}" rel="publisher"><i class="fab fa-slack-hash" style="padding-top: 10px;"></i></a>
-                      <li><a href="{{site.social.flickr}}"><i class="social foundicon-flickr"></i></a></li>
-                      <li><a href="{{site.social.instagram}}"><i class="social foundicon-instagram"></i></a></li>
-                      <li><a href="{{site.social.blogfeed}}"><i class="social foundicon-rss"></i></a></li>
-                      <li><a href="{{site.social.twitch}}" rel="publisher"><i class="fab fa-twitch" style="padding-top: 10px;"></i></a>
-                    </ul>
-                </div>
-            </div>
+      <div id="banner-wrap">
+        <div class="row">
+          <div class="small-12 columns">
+            <h1 class="banner">
+              <img id="header-logo" src="{{site.base}}/assets/img/logo-pride_60.png"/>
+
+              <a href="/">
+                <span class="fsl-purple">Farset</span><span class="fsl-green">Labs</span><small class="subheader"> BELFAST</small>
+              </a>
+            </h1>
+          </div>
         </div>
+      </div>
+
          <a id="forkMeButton" href="https://github.com/FarsetLabs/farsetlabs.github.io/"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork us on GitHub"></a>
         <div id="primary-nav">
             <div class="row">
@@ -195,25 +187,52 @@
           </div>
         </section>
     </div>
-    <footer id="footer">
-        <section class="attribution">
-        <div class="row">
-            <div class="small-6 columns">
-              {% capture footer %}
-                {% include pages/footer.md %}
-              {% endcapture %}
-              {{ footer | unindent | markdownify }}
+
+    <footer id="farset-labs-footer">
+        <section class="information">
+          <div class="row">
+            <div class="small-12 medium-6 columns">
+              <ul id="social-media-icons" class="inline-icons inline-list">
+                <li><a href="{{site.social.github}}" rel="publisher"><i class="social foundicon-github"></i></a></li>
+                <li><a href="{{site.social.twitter}}" rel="publisher"><i class="social foundicon-twitter"></i></a></li>
+                <li><a href="{{site.social.facebook}}" rel="publisher"><i class="social foundicon-facebook"></i></a></li>
+                <li><a href="{{site.social.slack}}" rel="publisher"><i class="fab fa-slack-hash" style="padding-top: 10px;"></i></a>
+                <li><a href="{{site.social.flickr}}"><i class="social foundicon-flickr"></i></a></li>
+                <li><a href="{{site.social.instagram}}"><i class="social foundicon-instagram"></i></a></li>
+                <li><a href="{{site.social.blogfeed}}"><i class="social foundicon-rss"></i></a></li>
+                <li><a href="{{site.social.twitch}}" rel="publisher"><i class="fab fa-twitch" style="padding-top: 10px;"></i></a>
+              </ul>
             </div>
-            <div class="small-6 columns text-right">
-		<a href="https://fundraisingregulator.org.uk">
-		  <img src="{{site.base}}/assets/img/fr_badge.png" alt='Registered with the Fundraising Regulator'>
-		</a>
-		</br>
+
+            <div class="columns small-12 medium-6">
+              <p>
+              <a href="https://www.farsetlabs.org.uk/">Farset Labs</a> is a <a href="https://www.charitycommissionni.org.uk/charity-details/?regId=102754&subId=0">Registered Charity (NIC102754)</a> and a non-profit <a href="https://beta.companieshouse.gov.uk/company/NI611278">Private Limited Company (NI611278)</a>, based in Belfast, Northern Ireland.
+              </p>
+              <div id="fundraising-regulator-badge">
+              <a href="https://fundraisingregulator.org.uk">
+                <img src="{{site.base}}/assets/img/fr_badge.png" alt='Registered with the Fundraising Regulator'>
+              </a>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="attribution-and-copyright">
+          <div class="row">
+            <div id="copyright" class="columns small-12 medium-6">
+              <p>
+                Copyright <a href="https://farsetlabs.org.uk">Farset Labs</a> {{ site.time | date: '%Y' }}.
+              </p>
+            </div>
+            <div id="attribution" class="columns small-12 medium-6">
+              <p>
                 <a href="http://jekyllrb.com">Jekyll</a> theme by <a href="http://argskwargs.io">averagehuman</a>.
+              </p>
             </div>
-        </div>
+          </div>
         </section>
     </footer>
+
     <script src="{{site.base}}/assets/foundation/js/foundation.js"></script>
     <script src="{{site.base}}/assets/foundation/js/foundation.topbar.js"></script>
     <script src="{{site.base}}/assets/js/toc.js"></script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -138,3 +138,48 @@ a {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+
+#farset-labs-footer {
+  color: #efefef;
+  background-color: #3e3e3e;
+}
+#farset-labs-footer a {
+  color: #99ca3c;
+}
+
+#farset-labs-footer a:hover {
+  color: #b1d76a;
+}
+
+.information {
+  padding: 12px 0;
+}
+
+.attribution-and-copyright {
+  padding: 12px 0;
+  background-color: #333333;
+}
+
+#copyright p {
+  margin: 0;
+}
+
+#attribution p {
+  margin: 0;
+}
+
+#fundraising-regulator-badge {
+  background: white;
+  border-radius: 3px;
+  border: 2px solid #99ca3c;
+}
+
+#header-logo {
+  height: 40px;
+}
+
+#social-media-icons {
+  margin-bottom: 15px !important;
+  padding-top: 0 !important;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -181,5 +181,5 @@ a {
 
 #social-media-icons {
   margin-bottom: 15px !important;
-  padding-top: 0 !important;
+  padding-top: 5px !important;
 }


### PR DESCRIPTION
Closes #276.

## Description

At the moment landing on our website on mobile shows our header taking up between 1/3 and 1/4 of the screen Let's move our overpopulated social media icons into the footer to prevent them breaking layout. 

Additionally, adjusting footer layout.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/84960365-53f2fc80-b0f9-11ea-9e81-bdc8f88c11fd.png) | ![image](https://user-images.githubusercontent.com/13058213/84960388-5fdebe80-b0f9-11ea-98c3-40f9f795c977.png)
![image](https://user-images.githubusercontent.com/13058213/84960225-fc549100-b0f8-11ea-8d8a-e549284fc260.png) | ![image](https://user-images.githubusercontent.com/13058213/84960234-01194500-b0f9-11ea-83d1-3a8427d874d4.png)