### PR TITLE
Update bundler version and pin docker base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM            jekyll/jekyll
+FROM            jekyll/jekyll:3
 EXPOSE          4000
 
 COPY            Gemfile* /tmp/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,4 +245,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   1.17.1
+   2.0.2


### PR DESCRIPTION
## Description

The base docker image installs bundler `2.0.2`, so the bundle command fails because it can't find a version 1 bundler installation.

Update the version in the `gemfile.lock` file to match the installed version.