### PR TITLE
[No Issue] Remove Social Links from Navigation Bar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,19 +26,6 @@ social:
 links:
   - name: Blog
     url: "https://blog.farsetlabs.org.uk/"
-  - name: Social
-    url: ""
-    list:
-    - name: Facebook
-      url: "https://facebook.com/FarsetLabs"
-    - name: Twitter
-      url: "https://twitter.com/FarsetLabs"
-    - name: Slack
-      url: "https://farsetlabs.org.uk/slack"
-    - name: Blog
-      url: "https://blog.farsetlabs.org.uk/"
-    - name: Flickr
-      url: "https://www.flickr.com/groups/farset_labs"
 officers:
   - name: Andrew Bolster
     username: bolster


### PR DESCRIPTION
[(Example) ISSUE-247](https://github.com/FarsetLabs/farsetlabs.github.io/issues/247)

## Description

Let's clear up the top navigation.

Our top navigation bar is a bit cluttered and we've already got social links displayed in the website footer, which is the common approach these days.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/87246264-2c672980-c444-11ea-9850-79e9ac3be3f5.png) | ![image](https://user-images.githubusercontent.com/13058213/87246266-325d0a80-c444-11ea-9abf-f8ed745cac19.png)

