### PR TITLE
[ISSUE-267] Add "Edit this page on GitHub" Link to All Pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -202,6 +202,14 @@
       </section>
     </div>
 
+    <div class="row">
+      <div class="small-12 columns">
+        <p>
+          {% github_edit_link "Edit this page on GitHub" %} to help us improve the website.
+        </p>
+      </div>
+    </div>
+
     <footer id="farset-labs-footer">
       <section class="information">
         <div class="row">


### PR DESCRIPTION
Closes #267.

## Description

Let's add a link to "edit this page on GitHub". I've seen this done on a bunch of community maintained websites (mostly for open source projects).

Easier on-the-fly edits to the website and lower technical barrier to suggesting edits.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/13058213/88338266-04bf6d80-cd30-11ea-8b70-6f48ed41c4a3.png) | ![image](https://user-images.githubusercontent.com/13058213/88338291-0c7f1200-cd30-11ea-8578-0eadfc0424d8.png)