### PR TITLE
Fix strikethroughs on the COVID page

### DIFF
--- a/coronavirus.md
+++ b/coronavirus.md
@@ -82,27 +82,27 @@ to work and using shared facilities. **Signage and sectioning** will be in place
 * ~~❌ Public events: No~~
 * ~~💻 Hackerspace meetings (eg: town hall): Remote~~
 
-#### ~Step 3~
+#### ~~Step 3~~
 
-~The space is open to members that went through COVID-19 onboarding and guests under their supervision, but not public events, and all hackerspace meetings are remote.~
+~~The space is open to members that went through COVID-19 onboarding and guests under their supervision, but not public events, and all hackerspace meetings are remote.~~
 
-~Coming in to the space is conditional on attending COVID-19 onboarding and agreeing to our [return policy].~
+~~Coming in to the space is conditional on attending COVID-19 onboarding and agreeing to our [return policy].~~
 
-* ~✅ Visitors: Yes, members can bring up to 4 guests under their supervision.~
-* ~✅ Members: Yes~
-* ~❌ Public events: No~
-* ~💻 Hackerspace meetings (eg: town hall): Remote~
+* ~~✅ Visitors: Yes, members can bring up to 4 guests under their supervision.~~
+* ~~✅ Members: Yes~~
+* ~~❌ Public events: No~~
+* ~~💻 Hackerspace meetings (eg: town hall): Remote~~
 
-#### Step 4
+#### ~~Step 4~~
 
-~The space is open to members that went through COVID-19 onboarding and guests under their supervision, but not public events, and all hackerspace meetings are remote.~
+~~The space is open to members that went through COVID-19 onboarding and guests under their supervision, but not public events, and all hackerspace meetings are remote.~~
 
-~Coming in to the space is conditional on attending COVID-19 onboarding and agreeing to our [return policy].~
+~~Coming in to the space is conditional on attending COVID-19 onboarding and agreeing to our [return policy].~~
 
-* ~✅ Visitors: Yes, members can bring up to 4 guests under their supervision.~
-* ~✅ Members: Yes~
-* ~❌ Public events: No~
-* ~💻 Hackerspace meetings (eg: town hall): Yes, remote~
+* ~~✅ Visitors: Yes, members can bring up to 4 guests under their supervision.~~
+* ~~✅ Members: Yes~~
+* ~~❌ Public events: No~~
+* ~~💻 Hackerspace meetings (eg: town hall): Yes, remote~~
 
 #### Step 5
 


### PR DESCRIPTION
## Description

Fixes the strikethroughs on steps 3 and 4 of the covid information page.

Before | After
--- | ---
<img width="786" alt="Screenshot 2021-05-27 at 13 37 39" src="https://user-images.githubusercontent.com/25768210/119827223-cdda5b00-bef0-11eb-80f7-6a95d2d86d60.png"> | <img width="800" alt="Screenshot 2021-05-27 at 13 37 52" src="https://user-images.githubusercontent.com/25768210/119827259-d763c300-bef0-11eb-9717-0b0163ec0fdb.png">

