### PR TITLE
Remove Slack Link from Website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,6 @@ social:
   twitter: "https://www.twitter.com/FarsetLabs"
   flickr: "https://www.flickr.com/groups/farset_labs"
   blogfeed: "https://blog.farsetlabs.org.uk/feed/"
-  slack: "http://slackin.farsetlabs.org.uk/"
   twitch: "https://www.twitch.tv/farsetlabs"
   instagram: "https://www.instagram.com/farsetlabs"
 links:

--- a/_includes/pages/about_farset.md
+++ b/_includes/pages/about_farset.md
@@ -2,4 +2,4 @@
 ### Who We Are
 We are an open community of students, professionals, academics, freelancers, artists, hackers, and organizers that believe strongly in experimental learning and the Do-It-Yourself ethic. We facilitate technology initiatives and encourage hands-on learning by maintaining a [workshop](/about/facility.html) and creative space that is available to members. We maintain an inclusive membership [policy](/about/rules_and_policies.html), and strive to apply the principles of the open-software and open-hardware movements within our design policies.
 
-The space is available to members 24/7 but if you would like to pop in, give us a shout on [Twitter](https://twitter.com/farsetlabs) or [Slack](https://farsetlabs.org.uk/slack) to see if anyone is about!
+The space is available to members 24/7 but if you would like to pop in, give us a shout on [Twitter](https://twitter.com/farsetlabs) or Slack to see if anyone is about!

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -231,11 +231,6 @@
                 </a>
               </li>
               <li>
-                <a href="{{site.social.slack}}" rel="publisher">
-                  <i class="fab fa-slack"></i>
-                </a>
-              </li>
-              <li>
                 <a href="{{site.social.flickr}}">
                   <i class="fab fa-flickr"></i>
                 </a>

--- a/coronavirus.md
+++ b/coronavirus.md
@@ -19,13 +19,12 @@ _Last reviewed on the 24th of May 2021._
 
 ### Frequently Asked Questions (FAQs)
 
-Ask questions and we will add answers here. Get in touch on [Slack] or through [info@farsetlabs.org.uk].
+Ask questions and we will add answers here. Get in touch on Slack or through [info@farsetlabs.org.uk].
 
 #### Do I have to wear a mask in the space?
 
 No, they are available but not mandatory while you are in the space as of 13th of July. Government guidelines may change.
 
-[Slack]:{{site.social.slack}}
 [info@farsetlabs.org.uk]:mailto:info@farsetlabs.org.uk
 
 #### Where is the form I need to submit before going to the space?
@@ -34,7 +33,7 @@ Here you go, it's available online: [Farset Labs COVID-19 Policy Agreement].
 
 #### Can I run an event with more than 15 people?
 
-Yes, but an additional step is required. Contact us on [Slack] (preferred) or through [info@farsetlabs.org.uk] and we'll complete a risk assessment for your event, which is required for indoor events of more than 15 people.
+Yes, but an additional step is required. Contact us on Slack (preferred) or through [info@farsetlabs.org.uk] and we'll complete a risk assessment for your event, which is required for indoor events of more than 15 people.
 
 ---
 

--- a/farsetlabs.json
+++ b/farsetlabs.json
@@ -10,7 +10,6 @@
         "github":"https://github.com/FarsetLabs",
         "twitter": "@farsetlabs",
         "facebook": "https://www.facebook.com/FarsetLabs",
-        "slack": "http://slackin.farsetlabs.org.uk/",
         "flickr": "http://www.flickr.com/groups/farset_labs",
         "instagram":"https://www.instagram.com/farsetlabs",
         "irc": "irc://irc.freenode.net/#farsetlabs",

--- a/slack/index.md
+++ b/slack/index.md
@@ -1,3 +1,0 @@
----
-redirect_to: https://slackin.farsetlabs.org.uk/
----


### PR DESCRIPTION
## Description

[Take down public Slack link](https://trello.com/c/2RBxXh0S/75-take-down-public-slack-link)

In the past month we've had 3 spammers joined our Slack, and in general some people find us and join the Slack for a day and never signing in again. We have a limit of 250 members under the charity tier, before we need to start paying per member.

Let's take down the public Slack link and see if this helps, if it doesn't we can look at taking down the auto-inviting app, too.

