### PR TITLE
Show board roles on our website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ links:
   - name: Blog
     url: "https://blog.farsetlabs.org.uk/"
 officers:
-  - name: Andrew Bolster
+  - name: Andrew Bolster, Secretary
     pronouns: "he/him"
     username: bolster
     year: 2011 -
@@ -40,7 +40,7 @@ officers:
     github: "andrewbolster"
     discourse: "bolster"
 
-  - name: Dylan Wylie
+  - name: Dylan Wylie, Treasurer
     pronouns: "he/him"
     username: wylie
     year: 2013 -
@@ -60,7 +60,7 @@ officers:
     twitter: "pixelpage"
     linkedin: "colinmitch"
 
-  - name: Artemiy Kondratiev
+  - name: Artemiy Kondratiev, Chair
     pronouns: "he/him"
     username: art
     year: 2018 -


### PR DESCRIPTION
We are moving towards segmenting roles & responsibilities, rather than everybody needing to know everything on an ad-hoc basis. Our roles are taken from the DIY Committee guidance, and we'll be figuring out their implementation for Farset Labs over the current quarter.

* Art, [Chair](https://www.diycommitteeguide.org/code/principle/what-role-chairperson)
* Dylan, [Treasurer](https://www.diycommitteeguide.org/resource/what-role-treasurer)
* Andrew, [Secretary](https://www.diycommitteeguide.org/resource/what-role-secretary)