### PR TITLE
Add Member Handbook to Navigation

### DIFF
--- a/member-handbook.md
+++ b/member-handbook.md
@@ -1,0 +1,6 @@
+---
+title: Member Handbook
+category: nav
+weight: 7
+redirect_to: https://farsetlabs.org.uk/member-handbook
+---


### PR DESCRIPTION
Adding a link to the Member Handbook from the website. Navigation will shift and need adjusting.