### PR TITLE
Revert "Add Member Handbook to Navigation"

### DIFF
--- a/member-handbook.md
+++ b/member-handbook.md
@@ -1,6 +1,0 @@
----
-title: Member Handbook
-category: nav
-weight: 7
-redirect_to: https://farsetlabs.org.uk/member-handbook
----


### PR DESCRIPTION
Reverts FarsetLabs/farsetlabs.github.io#363

![image](https://user-images.githubusercontent.com/88642/159329985-fca5ee81-2637-4447-9af0-987667222ade.png)

Breaks nav layout and raises a cert failure on clickthrough.