### PR TITLE
Remove Matterport IFrame and revert to original carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,12 @@
 ---
 layout: default
 title: Farset Labs - Home
+image: /assets/img/space/ground-floor-1.jpg
+carousel:
+ - image: /assets/img/carousels/frontpage/slide1.jpg
+ - image: /assets/img/carousels/frontpage/slide2.jpg
+ - image: /assets/img/carousels/frontpage/slide3.jpg
 ---
-
-<div id="model-container">
-  <div class="centered">
-    <iframe src="https://my.matterport.com/show/?m=FF6T3aJ7eHL" frameborder="0" allowfullscreen allow="xr-spatial-tracking"></iframe>
-  </div>
-</div>
-
 <div>
   <p>
     <b>Farset Labs</b>


### PR DESCRIPTION
Reviewed Locally.

Consensus on #389 required to replace, but also don't want a blank space on the website.