### PR TITLE
Replace Ecwid store with Spreadshirt shop

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,8 @@ social:
 links:
   - name: Blog
     url: "https://blog.farsetlabs.org.uk/"
+  - name: Shop
+    url: "https://farset-labs.myspreadshop.co.uk"
 officers:
   - name: Andrew Bolster, Treasurer 
     pronouns: "he/him"

--- a/store.md
+++ b/store.md
@@ -1,9 +1,0 @@
----
-title: Store
-category: nav
-weight: 6
----
-<div id="my-store-84183059"></div>
-<div>
-<script data-cfasync="false" type="text/javascript" src="https://app.ecwid.com/script.js?84183059&data_platform=code&data_date=2023-02-05" charset="utf-8"></script><script type="text/javascript"> xProductBrowser("categoriesPerRow=3","views=grid(20,3) list(60) table(60)","categoryView=grid","searchView=list","id=my-store-84183059");</script>
-</div>


### PR DESCRIPTION
## Description

Replaces the embedded Ecwid store with a link to our Spreadshop.

You _can_ embed a Spreadshop but it literally displays the entire page in the frame and it doesn't look very good and I don't have time to try to optimise the shop to make it work, so this feels like a decent tradeoff.

Before | After
--- | ---
<img width="770" alt="Screenshot 2024-01-22 at 20 59 10" src="https://github.com/FarsetLabs/farsetlabs.github.io/assets/25768210/a278fbd2-ec33-4e4b-8647-e6879ba8f0b2"> | <img width="771" alt="Screenshot 2024-01-22 at 20 56 57" src="https://github.com/FarsetLabs/farsetlabs.github.io/assets/25768210/1b701df7-938b-464a-8910-ca370cdbba11">

