### PR TITLE
Remove trailing slash to fix event links

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ carousel:
     <b>Farset Labs</b>
     is a community funded and volunteer operated charity, opened in 2012 as a place for creativity and technological tinkering.
     We’re open to everyone, no matter what you want to do, and we welcome people from all walks of life to use our space,
-    <a href="{{site.base}}/events/">come to our events</a>, and get involved with the maker community in Northern Ireland.
+    <a href="{{site.base}}/events">come to our events</a>, and get involved with the maker community in Northern Ireland.
     <a href="{{site.base}}/about/who_we_are">Read more about us!</a>
   </p>
 </div>
@@ -27,7 +27,7 @@ carousel:
         <p>Becoming a member of the Labs
           <a href="/about/facility">opens the doors to our resources and space</a>
           any time, as well as
-          <a href="/events/">free access to events</a>.
+          <a href="/events">free access to events</a>.
           Long-term desk rental is also available for members.
         </p>
         <a class="button expand round" href="/membership">Join as a Member</a>
@@ -62,7 +62,7 @@ carousel:
       </legend>
       <iframe frameborder="0" height="240" scrolling="no" src="https://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=200&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=farsetlabs.org.uk_srmqnkn373auq51u00s2nijrq8%40group.calendar.google.com&amp;color=%235F6B02&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="318"></iframe>
       <p class="text-right">
-        <a href="{{site.base}}/events/">More Events...</a>
+        <a href="{{site.base}}/events">More Events...</a>
       </p>
     </fieldset>
   </div>

--- a/shop/club_mate.md
+++ b/shop/club_mate.md
@@ -34,9 +34,6 @@ If you would like to order (for collection only), please order here!
 <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeOy9bXEpTl5UowpSB1ubudoWwwCY1HTwvpQGr9xuEI_NY-Xg/viewform?embedded=true" width="100%" height="854" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
 
 [Club-mate]: http://www.clubmate.de/
-[fuel-of-choice]:
-  https://www.vice.com/en/article/xywxm7/how-a-german-soda-became-hackers-fuel-of-choice
-[form]:
-  https://docs.google.com/forms/d/1fUgrvDnktPW1WM3YsBpFMWUZP5qGrD7Ktu1vsmCVp4s/closedform
-[mailing list]:
-  https://docs.google.com/forms/d/1rRXpidMTPJrlrwpWK2t31LoedhtMy41OJRMjZA9ok_c/viewform
+[fuel-of-choice]: https://www.vice.com/en/article/xywxm7/how-a-german-soda-became-hackers-fuel-of-choice
+[form]: https://docs.google.com/forms/d/1fUgrvDnktPW1WM3YsBpFMWUZP5qGrD7Ktu1vsmCVp4s/closedform
+[mailing list]: https://docs.google.com/forms/d/1rRXpidMTPJrlrwpWK2t31LoedhtMy41OJRMjZA9ok_c/viewform


### PR DESCRIPTION
Quick follow-up fixes
* Formatting the markdown variables on the clubmate page made Jekyll confused (probably because it’s after some HTML), so revert this.
* Remove trailing `/` from events — Github pages / Jekyll doesn’t support this and they’re 404ing