### PR TITLE
Update Jekyll routes to support optional trailing slash

### DIFF
--- a/about/charitable_aims.md
+++ b/about/charitable_aims.md
@@ -5,7 +5,7 @@ parent: About
 weight: 4
 toc: True
 tags: []
-permalink: /about/charitable_aims
+permalink: /about/charitable_aims/
 ---
 
 # {{ page.title }}

--- a/about/contributors.html
+++ b/about/contributors.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Contributors
-permalink: /about/contributors
+permalink: /about/contributors/
 ---
 
 {% comment %}Using the jekyll-github-metadata plugin included with github-pages.{% endcomment %}

--- a/about/facility.md
+++ b/about/facility.md
@@ -5,7 +5,7 @@ parent: "About"
 weight: 1
 image: /assets/img/space/workshop-1.jpg
 toc: False
-permalink: /about/facility
+permalink: /about/facility/
 ---
 
 # Facilities & Resources

--- a/about/getting_here.md
+++ b/about/getting_here.md
@@ -3,7 +3,7 @@ layout: default
 title: Location
 parent: "About"
 weight: 2
-permalink: /about/getting_here
+permalink: /about/getting_here/
 ---
 
 # How to Find Farset Labs

--- a/about/index.md
+++ b/about/index.md
@@ -2,7 +2,7 @@
 title: About
 category: nav
 weight: 4
-permalink: /about
-redirect_to: /about/who_we_are
+permalink: /about/
+redirect_to: /about/who_we_are/
 haschildren: True
 ---

--- a/about/who_we_are.html
+++ b/about/who_we_are.html
@@ -3,7 +3,7 @@ layout: default
 title: Who We Are
 parent: "About"
 weight: 3
-permalink: /about/who_we_are
+permalink: /about/who_we_are/
 ---
 
 <h2>About Farset Labs</h2>

--- a/community/cctv.md
+++ b/community/cctv.md
@@ -3,8 +3,8 @@ layout: default
 title: CCTV Policy
 parent: "Community"
 weight: 4
-redirect_from: /about/cctv
-permalink: /community/cctv
+redirect_from: /about/cctv/
+permalink: /community/cctv/
 ---
 
 # CCTV Policy and Procedures

--- a/community/child_protection.md
+++ b/community/child_protection.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: True
 tags: []
-redirect_from: /about/child_protection
-permalink: /community/child_protection
+redirect_from: /about/child_protection/
+permalink: /community/child_protection/
 ---
 
 # {{ page.title }}

--- a/community/clearance.md
+++ b/community/clearance.md
@@ -2,8 +2,8 @@
 title: Clearance Guidelines
 layout: default
 toc: False
-redirect_from: /about/clearance
-permalink: /community/clearance
+redirect_from: /about/clearance/
+permalink: /community/clearance/
 ---
 
 A single "Ticket List" Google Doc will be kept in Slack to record any items that

--- a/community/code_of_conduct.md
+++ b/community/code_of_conduct.md
@@ -4,8 +4,8 @@ layout: default
 parent: "Community"
 toc: True
 weight: 3
-redirect_from: /about/code_of_conduct
-permalink: /community/code_of_conduct
+redirect_from: /about/code_of_conduct/
+permalink: /community/code_of_conduct/
 ---
 
 ## Code of Conduct for Members

--- a/community/equality.md
+++ b/community/equality.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: True
 tags: []
-redirect_from: /about/equality
-permalink: /community/equality
+redirect_from: /about/equality/
+permalink: /community/equality/
 ---
 
 # Statement of {{ page.title }}

--- a/community/expenses_purchasing.md
+++ b/community/expenses_purchasing.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: True
 tags: []
-redirect_from: /about/expenses_purchasing
-permalink: /community/expenses_purchasing
+redirect_from: /about/expenses_purchasing/
+permalink: /community/expenses_purchasing/
 ---
 
 # Purpose

--- a/community/hardware_donation_license.md
+++ b/community/hardware_donation_license.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: True
 tags: []
-redirect_from: /about/hardware_donation_license
-permalink: /community/hardware_donation_license
+redirect_from: /about/hardware_donation_license/
+permalink: /community/hardware_donation_license/
 ---
 
 # Extendible Hardware Donation License v1.0

--- a/community/index.md
+++ b/community/index.md
@@ -2,7 +2,7 @@
 title: Community
 category: nav
 weight: 5
-permalink: /community
-redirect_to: /community/member_handbook
+permalink: /community/
+redirect_to: /community/member_handbook/
 haschildren: True
 ---

--- a/community/member_handbook.md
+++ b/community/member_handbook.md
@@ -3,6 +3,6 @@ title: Member Handbook
 parent: Community
 weight: 1
 redirect_to: https://www.farsetlabs.org.uk/member-handbook
-redirect_from: /about/member_handbook
-permalink: /community/member_handbook
+redirect_from: /about/member_handbook/
+permalink: /community/member_handbook/
 ---

--- a/community/net_conf.md
+++ b/community/net_conf.md
@@ -1,8 +1,8 @@
 ---
 title: Network Configuration
 layout: default
-redirect_from: /about/net_conf
-permalink: /community/net_conf
+redirect_from: /about/net_conf/
+permalink: /community/net_conf/
 ---
 
 # Network Configuration

--- a/community/ops_manual.md
+++ b/community/ops_manual.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: False
 tags: []
-redirect_from: /about/ops_manual
-permalink: /community/ops_manual
+redirect_from: /about/ops_manual/
+permalink: /community/ops_manual/
 ---
 
 # {{ page.title }}

--- a/community/reserves_policy.md
+++ b/community/reserves_policy.md
@@ -4,8 +4,8 @@ layout: default
 category: pages
 toc: True
 tags: []
-redirect_from: /about/reserves_policy
-permalink: /community/reserves_policy
+redirect_from: /about/reserves_policy/
+permalink: /community/reserves_policy/
 ---
 
 # {{ page.title }}

--- a/community/rules_and_policies.md
+++ b/community/rules_and_policies.md
@@ -4,8 +4,8 @@ layout: default
 parent: "Community"
 toc: False
 weight: 2
-redirect_from: /about/rules_and_policies
-permalink: /community/rules_and_policies
+redirect_from: /about/rules_and_policies/
+permalink: /community/rules_and_policies/
 ---
 
 # The Short Rules

--- a/community/sponsored_membership_policy.md
+++ b/community/sponsored_membership_policy.md
@@ -7,8 +7,8 @@ haschildren: False
 toc: False
 weight: 4
 tags: []
-redirect_from: /about/sponsored_membership_policy
-permalink: /community/sponsored_membership_policy
+redirect_from: /about/sponsored_membership_policy/
+permalink: /community/sponsored_membership_policy/
 ---
 
 # Sponsored Membership Policy

--- a/events/book_a_room.md
+++ b/events/book_a_room.md
@@ -4,9 +4,9 @@ title: Book a Room
 parent: "Events"
 weight: 2
 redirect_from:
-  - /events/how-to-start-a-class
-  - /events/room_availability
-permalink: /events/book_a_room
+  - /events/how-to-start-a-class/
+  - /events/room_availability/
+permalink: /events/book_a_room/
 ---
 
 # Room Availability

--- a/events/index.md
+++ b/events/index.md
@@ -2,8 +2,8 @@
 title: Events
 category: nav
 weight: 2
-permalink: /events
-redirect_from: /calendar
-redirect_to: /events/whats_on
+permalink: /events/
+redirect_from: /calendar/
+redirect_to: /events/whats_on/
 haschildren: True
 ---

--- a/events/makernight.md
+++ b/events/makernight.md
@@ -3,7 +3,7 @@ title: Maker Night
 parent: "Events & Classes"
 image: /events/makernight.jpg
 layout: default
-permalink: /events/makernight
+permalink: /events/makernight/
 ---
 
 ![Maker Night](/events/makernight.jpg)

--- a/events/whats_on.md
+++ b/events/whats_on.md
@@ -6,7 +6,7 @@ weight: 1
 image: /assets/img/space/event-space-1.jpg
 carousel:
   - image: /assets/img/space/event-space-1.jpg
-permalink: /events/whats_on
+permalink: /events/whats_on/
 ---
 
 Looking to book an event? See [booking a room](/events/book_a_room) for details

--- a/membership.md
+++ b/membership.md
@@ -2,6 +2,6 @@
 title: Join
 category: nav
 weight: 1
-permalink: /membership
+permalink: /membership/
 redirect_to: https://farsetlabs.spaces.nexudus.com/
 ---

--- a/shop/club_mate.md
+++ b/shop/club_mate.md
@@ -3,8 +3,8 @@ layout: default
 title: Club-Mate
 parent: "Shop"
 weight: 2
-redirect_from: /about/club_mate
-permalink: /shop/club_mate
+redirect_from: /about/club_mate/
+permalink: /shop/club_mate/
 ---
 
 # Club-Mate

--- a/shop/index.md
+++ b/shop/index.md
@@ -2,7 +2,7 @@
 title: Shop
 category: nav
 weight: 6
-permalink: /shop
-redirect_to: /shop/merch
+permalink: /shop/
+redirect_to: /shop/merch/
 haschildren: True
 ---

--- a/shop/merch.md
+++ b/shop/merch.md
@@ -3,5 +3,5 @@ title: Merch
 parent: "Shop"
 weight: 1
 redirect_to: "https://farset-labs.myspreadshop.co.uk"
-permalink: /shop/merch
+permalink: /shop/merch/
 ---

--- a/support/corporates.md
+++ b/support/corporates.md
@@ -3,7 +3,7 @@ layout: default
 title: Supporters
 parent: "Support"
 weight: 3
-permalink: /support/corporates
+permalink: /support/corporates/
 ---
 
 For companies that think what we're doing is great, we offer them a way to help

--- a/support/donate.md
+++ b/support/donate.md
@@ -3,8 +3,8 @@ layout: default
 title: Donations
 parent: "Support"
 weight: 1
-redirect_from: /donate
-permalink: /support/donate
+redirect_from: /donate/
+permalink: /support/donate/
 ---
 
 ## One Off Donations

--- a/support/equipment.md
+++ b/support/equipment.md
@@ -3,7 +3,7 @@ layout: default
 title: Donate Equipment
 parent: "Support"
 weight: 2
-permalink: /support/equipment
+permalink: /support/equipment/
 ---
 
 # Equipment/Materiel Donations

--- a/support/index.md
+++ b/support/index.md
@@ -2,7 +2,7 @@
 title: Support
 category: nav
 weight: 3
-permalink: /support
-redirect_to: /support/donate
+permalink: /support/
+redirect_to: /support/donate/
 haschildren: True
 ---


### PR DESCRIPTION
# Description

We have links in the wild which both contain and don't trailing a slash — those with the trailing slash now 404.
If the trailing slash is part of the route in the config (e.g. `permalink`), then Jekyll will support _adding_ it when it’s missing. This PR updates to add the slash to all config routes so that both with and without will work. 

https://stackoverflow.com/questions/54727643/trailing-slashes-in-jekyll-github-pages-site-cause-404

Example:
* Coming after netlify builds