### PR TITLE
Remove phone number

### DIFF
--- a/farsetlabs.json
+++ b/farsetlabs.json
@@ -12,8 +12,7 @@
         "facebook": "https://www.facebook.com/FarsetLabs",
         "flickr": "http://www.flickr.com/groups/farset_labs",
         "instagram":"https://www.instagram.com/farsetlabs",
-        "irc": "irc://irc.freenode.net/#farsetlabs",
-        "phone": "+448458694619"
+        "irc": "irc://irc.freenode.net/#farsetlabs"
     },
     "issue_report_channels": [
         "email"

--- a/index.html
+++ b/index.html
@@ -77,10 +77,6 @@ carousel:
         <dd>
           <a href="mailto:info@farsetlabs.org.uk">info@farsetlabs.org.uk</a>
         </dd>
-        <dt>Phone</dt>
-        <dd>
-          <a href="tel:+448458694619">+44 845 869 4619</a>
-        </dd>
         <dt>Address</dt>
         <dd>
           <address>


### PR DESCRIPTION
Removes the phone number from the website. Although it is still active, it's not regularly monitored.

### Before
<img width="1840" alt="Screenshot 2024-02-14 at 13 00 04" src="https://github.com/FarsetLabs/farsetlabs.github.io/assets/635903/f98fe8b0-9517-4fd4-acf0-df7115daad40">

### After
<img width="1840" alt="Screenshot 2024-02-14 at 13 00 17" src="https://github.com/FarsetLabs/farsetlabs.github.io/assets/635903/77188b89-0134-4926-be27-d57d08272e11">
