### PR TITLE
Adds shorter URLs to be used in QR codes on internal signage

### DIFF
--- a/redirects/3d-printers.md
+++ b/redirects/3d-printers.md
@@ -1,0 +1,5 @@
+---
+title: 3D Printers
+redirect_to: "https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/training#3d-printers"
+permalink: /workshop/3d-printers/
+---

--- a/redirects/cnc-machine.md
+++ b/redirects/cnc-machine.md
@@ -1,0 +1,5 @@
+---
+title: CNC Machine
+redirect_to: "https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/FoxAlienCNC"
+permalink: /workshop/cnc-machine/
+---

--- a/redirects/laser-cutter.md
+++ b/redirects/laser-cutter.md
@@ -1,0 +1,5 @@
+---
+title: Laser Cutter
+redirect_to: "https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/training#laser-cutter"
+permalink: /workshop/laser-cutter/
+---

--- a/redirects/resin-printers.md
+++ b/redirects/resin-printers.md
@@ -1,0 +1,5 @@
+---
+title: Resin Printers
+redirect_to: "https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/resin_printers"
+permalink: /workshop/resin-printers/
+---

--- a/redirects/slack.md
+++ b/redirects/slack.md
@@ -1,0 +1,5 @@
+---
+title: Slack
+redirect_to: "https://farsetlabs.slack.com/"
+permalink: /slack/
+---


### PR DESCRIPTION
## Description

Adds a set of redirects, which we can use on internal signage but allows changing in the future.

Redirecting to these pages:
 - https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/training#3d-printers
 - https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/FoxAlienCNC
 - https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/training#laser-cutter
 - https://www.farsetlabs.org.uk/member-handbook/rooms/workshop/resin_printers
 - https://farsetlabs.slack.com/

Preview of redirects:
 - https://deploy-preview-410--storied-crostata-fa92db.netlify.app/workshop/3d-printers/
 - https://deploy-preview-410--storied-crostata-fa92db.netlify.app/workshop/cnc-machine/
 - https://deploy-preview-410--storied-crostata-fa92db.netlify.app/workshop/laser-cutter/
 - https://deploy-preview-410--storied-crostata-fa92db.netlify.app/workshop/resin-printers/
 - https://deploy-preview-410--storied-crostata-fa92db.netlify.app/slack/
