### PR TITLE
Footer updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ social:
   flickr: "https://www.flickr.com/groups/farset_labs"
   twitch: "https://www.twitch.tv/farsetlabs"
   instagram: "https://www.instagram.com/farsetlabs"
+  linkedin: "https://uk.linkedin.com/company/farset-labs"
 officers:
   - name: Colin Mitchell, Secretary
     pronouns: "he/him"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -272,8 +272,7 @@
           <div class="columns small-12 medium-6" id="attribution">
             <p>
               <a href="http://jekyllrb.com">Jekyll</a>
-              theme by
-              <a href="http://argskwargs.io">averagehuman</a>.
+              theme by averagehuman.
             </p>
           </div>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -216,6 +216,11 @@
                 </a>
               </li>
               <li>
+                <a href="{{site.social.linkedin}}" rel="publisher">
+                  <i class="fab fa-linkedin"></i>
+                </a>
+              </li>
+              <li>
                 <a href="{{site.social.facebook}}" rel="publisher">
                   <i class="fab fa-facebook-square"></i>
                 </a>


### PR DESCRIPTION
## Description

Adds a link to LinkedIn to the social links in the footer.

Remove the hyperlink from the theme author's name in the footer. It's a dead link, can't find a working one for the same person.

![Screenshot 2024-05-30 at 21 09 21](https://github.com/FarsetLabs/farsetlabs.github.io/assets/25768210/3e069b6a-0272-4060-b25a-441a764a03c5)

