### PR TITLE
Fix menu icon on mobile

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,7 +89,7 @@
                       <a href="{{site.base}}/">Home</a>
                     </li>
                     <li class="toggle-topbar menu-icon">
-                      <a href="#">Menu</a>
+                      <a href="#"><span>Menu</span></a>
                     </li>
                   </ul>
                   <ul class="right">


### PR DESCRIPTION
Fixes #411 

## Description

Fixes the hamburger menu on mobile. For some reason it just needed the word `Menu` to be contained within a span. I assume something is adding an `:after` rule to it somewhere but I can't quite figure out what.

Before | After
--- | ---
![Screenshot 2024-07-12 at 19 37 48](https://github.com/user-attachments/assets/20c74c0b-a0d2-42d4-b17b-a808c4d49fea) ![Screenshot 2024-07-12 at 19 37 56](https://github.com/user-attachments/assets/f7972946-7e2f-43f7-bafe-7c21776f252a) | ![Screenshot 2024-07-12 at 19 36 41](https://github.com/user-attachments/assets/53b89029-4393-445c-ac6f-857d8338c027) ![Screenshot 2024-07-12 at 19 36 54](https://github.com/user-attachments/assets/20bee81d-0474-40c0-afb6-fbf919ffda7b)

