### PR TITLE
Add both Stripe and Nexudus options to login page

### DIFF
--- a/login/index.md
+++ b/login/index.md
@@ -1,0 +1,22 @@
+---
+title: Login
+category: nav
+weight: 1
+permalink: /login/
+---
+
+## Stripe
+
+If you signed up directly with Stripe, you can manage your subscription here.
+
+<p style="text-align: center;">
+  <a href="https://billing.stripe.com/p/login/28o1555Vt8wF5Py8ww" class="button expand round max-w-md">Stripe Sign In</a>
+</p>
+
+### Nexudus (legacy)
+
+If you're still on Nexudus, you can log in here. Please consider moving to Stripe, as we're currently migrating off Nexudus.
+
+<p style="text-align: center;">
+  <a href="https://farsetlabs.spaces.nexudus.com/home?&v=latest" class="button expand round max-w-md">Nexudus Sign in</a>
+</p>

--- a/membership.md
+++ b/membership.md
@@ -1,7 +1,0 @@
----
-title: Login
-category: nav
-weight: 1
-permalink: /login/
-redirect_to: https://billing.stripe.com/p/login/28o1555Vt8wF5Py8ww
----


### PR DESCRIPTION
## Description

Adds links to Stripe and Nexudus to a `/login` page. Before `/login` just redirected you straight to Stripe but many people are still on Nexudus (and people find it hard enough as it is to find Nexudus when they need it).

![Screenshot 2025-05-19 at 10 12 08](https://github.com/user-attachments/assets/6c4e2078-3adf-4e44-9ed3-1537c88d9871)

